### PR TITLE
Correct use of 'parameter' in pss privilege escalation & volume-types readmes

### DIFF
--- a/policies/pss-privilege-escalation/README.md
+++ b/policies/pss-privilege-escalation/README.md
@@ -2,8 +2,11 @@
 This Validating Admission Policy ensures that containers explicitly disallow privilege escalation.
 This policy is part of the Pod Security Standards provided by Kubernetes, found here - https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted.
 
+# Policy logic
+This policy evaluates `securityContext.allowPrivilegeEscalation` within `spec.containers[\*]`, `spec.initContainers[\*]` and `spec.ephemeralContainers[\*]`. For the API call to be accepted then for each and every container: `securityContext.allowPrivilegeEscalation` must be set to false.
+
 # Parameter used by the policy
-This policy evaluates securityContext.allowPrivilegeEscalation within spec.containers[\*], spec.initContainers[\*] and spec.ephemeralContainers[\*]. For the API call to be accepted then for each and every container: securityContext.allowPrivilegeEscalation must be set to false.
+This policy does not use parameters. Rules that are outlined by the PSS Restricted profile are enforced. 
 
 # Examples
 ### Pass

--- a/policies/pss-volume-types/README.md
+++ b/policies/pss-volume-types/README.md
@@ -2,17 +2,20 @@
 This Validating Admission Policy ensures that any defined volumes can only be of one of the allowed types.
 This policy is part of the Pod Security Standards provided by Kubernetes, found here - https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted.
 
-# Parameter used by the policy
-This policy evaluates spec.volumes[\*]. For the API call to be accepted then for each and every volume: one of the following fields must be set to a non-null value:
+# Policy logic
+This policy evaluates `spec.volumes[\*]`. For the API call to be accepted then for each and every volume: one of the following fields must be set to a non-null value:
 
-* spec.volumes[*].configMap
-* spec.volumes[*].csi
-* spec.volumes[*].downwardAPI
-* spec.volumes[*].emptyDir
-* spec.volumes[*].ephemeral
-* spec.volumes[*].persistentVolumeClaim
-* spec.volumes[*].projected
-* spec.volumes[*].secret
+* `spec.volumes[*].configMap`
+* `spec.volumes[*].csi`
+* `spec.volumes[*].downwardAPI`
+* `spec.volumes[*].emptyDir`
+* `spec.volumes[*].ephemeral`
+* `spec.volumes[*].persistentVolumeClaim`
+* `spec.volumes[*].projected`
+* `spec.volumes[*].secret`
+
+# Parameter used by the policy
+This policy does not use parameters. Rules that are outlined by the PSS Restricted profile are enforced. 
 
 # Examples
 ### Pass


### PR DESCRIPTION
Correct READMEs to ensure consistent use of language across policies.