### PR TITLE
Feature/support parentrefs in httproutefields policy

### DIFF
--- a/policies/httproute-fields/policy.yaml
+++ b/policies/httproute-fields/policy.yaml
@@ -18,6 +18,6 @@ spec:
     - expression: "!has(params.spec.allowedHostnames) || has(object.spec.hostnames) && object.spec.hostnames.all(h, h in params.spec.allowedHostnames)"
       message: "If allowedHostnames is set on the parameter, spec.hostnames must be present and each item must be on the spec.allowedHostnames list in the policy parameter"
       reason: Invalid
-    - expression: "!has(params.spec.allowedParentRefs) || object.spec.parentRefs.all(parentRef, params.spec.allowedParentRefs.exists(allowedParentRef, allowedParentRef.all(k, k in parentRef && parentRef[k] == allowedParentRef[k])))"
-      message: "If allowedParentRefs is set on the parameter, spec.parentRefs must be present and each item must match (by name) an entry from the spec.allowedParentRefs list in the policy parameter and contain all other key:value pairs specified by the parameter"
+    - expression: "!has(params.spec.allowedParentRefs) || has(object.spec.parentRefs) && object.spec.parentRefs.all(parentRef, params.spec.allowedParentRefs.exists(allowedParentRef, allowedParentRef.all(k, k in parentRef && parentRef[k] == allowedParentRef[k])))"
+      message: "If allowedParentRefs is set on the parameter, spec.parentRefs must be present and each item must contain all key:value pairs from the spec.allowedParentRefs list in the policy parameter"
       reason: Invalid

--- a/policies/httproute-fields/policy.yaml
+++ b/policies/httproute-fields/policy.yaml
@@ -15,6 +15,9 @@ spec:
       operations:  ["CREATE", "UPDATE"]
       resources:   ["httproutes"]
   validations:
-    - expression: "has(object.spec.hostnames) && has(params.spec.allowedHostnames) && object.spec.hostnames.all(h, h in params.spec.allowedHostnames)"
-      message: "spec.hostnames must be present and each item must be on the spec.allowedHostnames list in the policy parameter"
+    - expression: "!has(params.spec.allowedHostnames) || has(object.spec.hostnames) && object.spec.hostnames.all(h, h in params.spec.allowedHostnames)"
+      message: "If allowedHostnames is set on the parameter, spec.hostnames must be present and each item must be on the spec.allowedHostnames list in the policy parameter"
+      reason: Invalid
+    - expression: "!has(params.spec.allowedParentRefs) || object.spec.parentRefs.all(parentRef, params.spec.allowedParentRefs.exists(allowedParentRef, allowedParentRef.all(k, k in parentRef && parentRef[k] == allowedParentRef[k])))"
+      message: "If allowedParentRefs is set on the parameter, spec.parentRefs must be present and each item must match (by name) an entry from the spec.allowedParentRefs list in the policy parameter and contain all other key:value pairs specified by the parameter"
       reason: Invalid


### PR DESCRIPTION
Add policy logic and associated tests to allow the limiting of allowed ParentRefs in HTTPRoute objects by use of the allowedParentRefs key in VAPLibHTTPRouteFieldsParam objects.